### PR TITLE
evm types

### DIFF
--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -55,12 +55,19 @@ atomic64bit = []
 # passed (see https://github.com/AltSysrq/proptest/issues/124).
 break-dead-code = []
 
+evm = ["primitive-types"]
+
 [dependencies]
 bitflags = "1.0.1"
 
 # [dependencies.hashmap_core]
 # version = "0.1.5"
 # optional = true
+
+[dependencies.primitive-types]
+version = "0.10.1"
+optional = true
+features = ["std"]
 
 [dependencies.lazy_static]
 version = "1.2"

--- a/proptest/src/arbitrary/evm.rs
+++ b/proptest/src/arbitrary/evm.rs
@@ -1,0 +1,30 @@
+use primitive_types::{H128, H160, H256, H512, U128, U256, U512};
+
+use crate::strategy::Map;
+
+use super::Strategy;
+use super::{any, Arbitrary, StrategyFor};
+
+macro_rules! evm_impl {
+    ($t:ty, $bytes:literal) => {
+        impl Arbitrary for &t {
+            type Parameters = ();
+            type Strategy =
+                Map<StrategyFor<[u8; $bytes]>, fn([u8; $bytes]) -> Self>;
+
+            fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+                any::<[u8; $bytes]>().prop_map(|bytes| $t::from_slice(&bytes))
+            }
+        }
+    };
+}
+
+evm_impl!(H128, 16);
+evm_impl!(H160, 20);
+evm_impl!(H256, 32);
+evm_impl!(H512, 64);
+
+evm_impl!(U128, 16);
+evm_impl!(U256, 32);
+evm_impl!(U512, 64);
+

--- a/proptest/src/arbitrary/evm.rs
+++ b/proptest/src/arbitrary/evm.rs
@@ -14,26 +14,42 @@ use crate::strategy::Map;
 use super::Strategy;
 use super::{any, Arbitrary, StrategyFor};
 
-macro_rules! evm_impl {
+macro_rules! hash_impl {
     ($t:ty, $bytes:literal) => {
-        impl Arbitrary for &t {
+        impl Arbitrary for $t {
             type Parameters = ();
             type Strategy =
                 Map<StrategyFor<[u8; $bytes]>, fn([u8; $bytes]) -> Self>;
 
             fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-                any::<[u8; $bytes]>().prop_map(|bytes| $t::from_slice(&bytes))
+                any::<[u8; $bytes]>().prop_map(|bytes| <$t>::from_slice(&bytes))
             }
         }
     };
 }
 
-evm_impl!(H128, 16);
-evm_impl!(H160, 20);
-evm_impl!(H256, 32);
-evm_impl!(H512, 64);
+macro_rules! prim_impl {
+    ($t:ty, $u64s:literal) => {
+        impl Arbitrary for $t {
+            type Parameters = ();
+            type Strategy =
+                Map<StrategyFor<[u64; $u64s]>, fn([u64; $u64s]) -> Self>;
 
-evm_impl!(U128, 16);
-evm_impl!(U256, 32);
-evm_impl!(U512, 64);
+            fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+                fn map(i: [u64; $u64s]) -> $t {
+                    <$t> (i)
+                }
+                any::<[u64; $u64s]>().prop_map(map)
+            }
+        }
+    };
+}
 
+hash_impl!(H128, 16);
+hash_impl!(H160, 20);
+hash_impl!(H256, 32);
+hash_impl!(H512, 64);
+
+prim_impl!(U128, 2);
+prim_impl!(U256, 4);
+prim_impl!(U512, 8);

--- a/proptest/src/arbitrary/evm.rs
+++ b/proptest/src/arbitrary/evm.rs
@@ -36,10 +36,7 @@ macro_rules! prim_impl {
                 Map<StrategyFor<[u64; $u64s]>, fn([u64; $u64s]) -> Self>;
 
             fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-                fn map(i: [u64; $u64s]) -> $t {
-                    <$t> (i)
-                }
-                any::<[u64; $u64s]>().prop_map(map)
+                any::<[u64; $u64s]>().prop_map(Self)
             }
         }
     };
@@ -53,3 +50,4 @@ hash_impl!(H512, 64);
 prim_impl!(U128, 2);
 prim_impl!(U256, 4);
 prim_impl!(U512, 8);
+

--- a/proptest/src/arbitrary/evm.rs
+++ b/proptest/src/arbitrary/evm.rs
@@ -1,3 +1,12 @@
+//-
+// Copyright 2022 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use primitive_types::{H128, H160, H256, H512, U128, U256, U512};
 
 use crate::strategy::Map;

--- a/proptest/src/arbitrary/mod.rs
+++ b/proptest/src/arbitrary/mod.rs
@@ -42,6 +42,9 @@ mod _alloc;
 #[cfg(feature = "std")]
 mod _std;
 
+#[cfg(feature = "evm")]
+mod evm;
+
 pub use self::traits::*;
 
 //==============================================================================


### PR DESCRIPTION
Adds `Arbitrary` implementations for EVM primitives, gated behind the `evm` feature flag