### PR TITLE
bump primitive types version

### DIFF
--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -65,7 +65,7 @@ bitflags = "1.0.1"
 # optional = true
 
 [dependencies.primitive-types]
-version = "0.10.1"
+version = "0.11.1"
 optional = true
 features = ["std"]
 


### PR DESCRIPTION
Bump to use the same version of `primitive-types` as `chain-libs`